### PR TITLE
add rinkeby network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ wget https://raw.githubusercontent.com/acebusters/geth-healthcheck/master/index.
 ETHERSCAN_API_KEY=<etherscan_api_key> PORT=50336 node index.js
 ```
 
+for rinkeby network:
+```
+ETHERSCAN_API_KEY=<etherscan_api_key> PORT=50336 NETWORK=rinkeby node index.js
+```
+
 Make sure it is detached from the terminal. Make sure the port is open for incoming connections.
 
 ## License

--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@ const http = require('http');
 const https = require('https');
 const { exec } = require('child_process');
 
-const ETHERSCAN_URL = `https://api.etherscan.io/api?module=proxy&action=eth_blockNumber&apikey=${process.env.ETHERSCAN_API_KEY}`;
+const etherscanPrefix = process.env.NETWORK == 'rinkeby' ? 'rinkeby' : 'api';
+
+const ETHERSCAN_URL = `https://${etherscanPrefix}.etherscan.io/api?module=proxy&action=eth_blockNumber&apikey=${process.env.ETHERSCAN_API_KEY}`;
 const MAX_BLOCK_DIFFERENCE = 3;
 
 const getLocalBlockNum = () => {


### PR DESCRIPTION
run with `ETHERSCAN_API_KEY=<etherscan_api_key> PORT=50336 NETWORK=rinkeby node index.js`